### PR TITLE
Make building independent of the Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,41 @@ with the following coordinates:
 </dependency>
 ```
 
-Once you have the dependency registered, it's just a matter of adding the bundle to your `Application` class.
+Once you have the dependency registered, it's just a matter of adding `CassandraFactory` instances to your 
+`Configuration` class:
+
+```java
+public class YourAppConfig extends Configuration {
+
+    @Valid
+    @NotNull
+    private CassandraFactory cassandra = new CassandraFactory();
+
+    @JsonProperty("cassandra")
+    public CassandraFactory getCassandraFactory() {
+        return cassandra;
+    }
+
+    @JsonProperty("cassandra")
+    public void setCassandraFactory(CassandraFactory cassandra) {
+        this.cassandra = cassandra;
+    }
+}
+```
+
+Then, in your `Application`, build `Cluster` instances when you need them:
+
+```java
+public class YourApp extends Application<YourAppConfig> {
+    
+    @Override
+    public void run(YourAppConfig configuration, Environment environment) throws Exception {
+        Cluster cassandra = configuration.getCassandraFactory().build(environment);
+    }
+}
+```
+
+Alternatively, you may use the `CassandraBundle` to ensure a `Cluster` has been initialized during startup.
 `CassandraBundle` is abstract and requires you to implement a single method in order to provide the correct
 configuration (similar to the `dropwizard-hibernate` module).
 
@@ -70,7 +104,7 @@ public class YourApp extends Application<YourAppConfig> {
             new CassandraBundle<YourAppConfig>() {
                 @Override
                 protected CassandraFactory cassandraConfiguration(YourAppConfig appConfig) {
-                    return appConfig.getCassandraConfig();
+                    return appConfig.getCassandraFactory();
                 }
             };
 

--- a/src/main/java/org/stuartgunter/dropwizard/cassandra/CassandraBundle.java
+++ b/src/main/java/org/stuartgunter/dropwizard/cassandra/CassandraBundle.java
@@ -24,8 +24,6 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
 /**
  * A bundle for integrating with Cassandra.
  */
@@ -43,20 +41,9 @@ public abstract class CassandraBundle<C extends Configuration> implements Config
         final CassandraFactory cassandraConfig = cassandraConfiguration(configuration);
 
         LOG.debug("Building {} Cassandra cluster", cassandraConfig.getClusterName());
-        cluster = cassandraConfig.buildCluster();
+        cluster = cassandraConfig.build(environment);
 
         sessionFactory = new SessionFactory(cluster, cassandraConfig.getKeyspace());
-
-        LOG.debug("Registering {} Cassandra cluster for lifecycle management", cassandraConfig.getClusterName());
-        environment.lifecycle().manage(new CassandraManager(cluster, cassandraConfig.getShutdownGracePeriod()));
-
-        LOG.debug("Registering {} Cassandra health check", cassandraConfig.getClusterName());
-        environment.healthChecks().register(name("cassandra", cluster.getClusterName()), new CassandraHealthCheck(sessionFactory));
-
-        if (cassandraConfig.isMetricsEnabled()) {
-            LOG.debug("Registering {} Cassandra metrics", cassandraConfig.getClusterName());
-            environment.metrics().registerAll(new CassandraMetricSet(cluster));
-        }
     }
 
     @Override

--- a/src/test/java/org/stuartgunter/dropwizard/cassandra/CassandraBundleTest.java
+++ b/src/test/java/org/stuartgunter/dropwizard/cassandra/CassandraBundleTest.java
@@ -16,23 +16,17 @@
 
 package org.stuartgunter.dropwizard.cassandra;
 
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Metrics;
 import io.dropwizard.Configuration;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 public class CassandraBundleTest {
@@ -57,7 +51,7 @@ public class CassandraBundleTest {
         when(environment.lifecycle()).thenReturn(lifecycle);
         when(environment.metrics()).thenReturn(metrics);
         when(environment.healthChecks()).thenReturn(healthChecks);
-        when(cassandraFactory.buildCluster()).thenReturn(cluster);
+        when(cassandraFactory.build(any(Environment.class))).thenReturn(cluster);
         when(cluster.getClusterName()).thenReturn("test-cluster");
     }
 
@@ -65,43 +59,7 @@ public class CassandraBundleTest {
     public void buildsCluster() throws Exception {
         bundle.run(configuration, environment);
 
-        verify(cassandraFactory).buildCluster();
-    }
-
-    @Test
-    public void registersHealthCheck() throws Exception {
-        bundle.run(configuration, environment);
-
-        verify(healthChecks).register(eq("cassandra.test-cluster"), isA(CassandraHealthCheck.class));
-    }
-
-    @Test
-    public void registersMetricsWhenEnabled() throws Exception {
-        Metrics clusterMetrics = mock(Metrics.class);
-        MetricRegistry registry = mock(MetricRegistry.class);
-        Map<String, Metric> driverMetrics = Collections.emptyMap();
-        when(cluster.getMetrics()).thenReturn(clusterMetrics);
-        when(clusterMetrics.getRegistry()).thenReturn(registry);
-        when(registry.getMetrics()).thenReturn(driverMetrics);
-        when(cassandraFactory.isMetricsEnabled()).thenReturn(true);
-
-        bundle.run(configuration, environment);
-
-        verify(metrics).registerAll(isA(CassandraMetricSet.class));
-    }
-
-    @Test
-    public void doesNotRegistersMetricsWhenDisabled() throws Exception {
-        bundle.run(configuration, environment);
-
-        verifyZeroInteractions(metrics);
-    }
-
-    @Test
-    public void managesClusterLifecycle() throws Exception {
-        bundle.run(configuration, environment);
-
-        verify(lifecycle).manage(isA(CassandraManager.class));
+        verify(cassandraFactory).build(eq(environment));
     }
 
     @Test


### PR DESCRIPTION
It's not necessary to use a `Bundle` to initialize a `Cluster` instance, as it doesn't hook in to the server (e.g. Jersey) like Hibernate does.

Instead, it's better to have the `CassandraFactory` itself take the `Environment` and be responsible for managing, adding healthchecks and registering metrics.

I've preserved the `Bundle` API, to ensure existing code works. Also, the `Bundle` API is still the only way to use a `SessionFactory`, though that's largely cosmetic, as you can just call `Cluster#connect(keyspace)` yourself.

Note: tests updated and pass. `README.md` updated to reflect new API.
