### PR TITLE
Add build() overload that doesn't use Environment

### DIFF
--- a/src/main/java/org/stuartgunter/dropwizard/cassandra/CassandraFactory.java
+++ b/src/main/java/org/stuartgunter/dropwizard/cassandra/CassandraFactory.java
@@ -318,6 +318,15 @@ public class CassandraFactory {
         this.shutdownGracePeriod = shutdownGracePeriod;
     }
 
+    /**
+     * Builds a {@link Cluster} instance for the given {@link Environment}.
+     * <p/>
+     * The {@code environment} will be used for lifecycle management, as well as metrics and
+     * health-checks.
+     *
+     * @param environment the environment to manage the lifecycle, metrics and health-checks.
+     * @return a fully configured and managed {@link Cluster}.
+     */
     public Cluster build(Environment environment) {
         final Cluster cluster = build(environment.metrics(), environment.healthChecks());
 
@@ -327,6 +336,16 @@ public class CassandraFactory {
         return cluster;
     }
 
+    /**
+     * Builds a {@link Cluster} instance.
+     * <p/>
+     * The {@link MetricRegistry} will be used to register client metrics, and the {@link
+     * HealthCheckRegistry} to register client health-checks.
+     *
+     * @param metrics the registry to register client metrics.
+     * @param healthChecks the registry to register client health-checks.
+     * @return a fully configured {@link Cluster}.
+     */
     public Cluster build(MetricRegistry metrics, HealthCheckRegistry healthChecks) {
         final Cluster.Builder builder = Cluster.builder();
         builder.addContactPoints(contactPoints);


### PR DESCRIPTION
Sometimes, you will want to configure and build a `Cluster` instance using `CassandraFactory`, but you won't have an `Environment` available.

The common-case here is when writing a `ConfiguredCommand` that uses Cassandra (e.g. for a utility to execute your applications' DDL statements).

While we have no `Environment`, we can still register health-checks and metrics, but we cannot manage the Cluster lifecycle, as there's no Environment to tie its lifecycle to.

This is broadly following the idiom used by the Liquibase Commands in `dropwizard-migrations` and the `DataSourceFactory` it uses to configure connections.
