### PR TITLE
Upgraded to 2.0.3 Datastax Cassandra Driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.version>0.7.0</dropwizard.version>
-        <cassandra-driver.version>2.0.2</cassandra-driver.version>
+        <cassandra-driver.version>2.0.3</cassandra-driver.version>
         <powermock.version>1.5.4</powermock.version>
         <assertj.version>1.5.0</assertj.version>
     </properties>

--- a/src/test/java/org/stuartgunter/dropwizard/cassandra/pooling/PoolingOptionsFactoryTest.java
+++ b/src/test/java/org/stuartgunter/dropwizard/cassandra/pooling/PoolingOptionsFactoryTest.java
@@ -27,27 +27,28 @@ public class PoolingOptionsFactoryTest {
     @Test
     public void buildsPoolingOptionsWithConfiguredValues() throws Exception {
         final PoolingOptionsFactory factory = new PoolingOptionsFactory();
-        factory.setLocal(createHostDistanceOptions(1000, 2000, 3000, 4000));
-        factory.setRemote(createHostDistanceOptions(5000, 6000, 7000, 8000));
+        factory.setLocal(createHostDistanceOptions(8, 64, 0, 128));
+        factory.setRemote(createHostDistanceOptions(2, 64, 0, 128));
 
         final PoolingOptions poolingOptions = factory.build();
 
-        assertThat(poolingOptions.getCoreConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(1000);
-        assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(2000);
-        assertThat(poolingOptions.getMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL)).isEqualTo(3000);
-        assertThat(poolingOptions.getMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL)).isEqualTo(4000);
-        assertThat(poolingOptions.getCoreConnectionsPerHost(HostDistance.REMOTE)).isEqualTo(5000);
-        assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.REMOTE)).isEqualTo(6000);
-        assertThat(poolingOptions.getMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE)).isEqualTo(7000);
-        assertThat(poolingOptions.getMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE)).isEqualTo(8000);
+        assertThat(poolingOptions.getCoreConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(8);
+        assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.LOCAL)).isEqualTo(64);
+        assertThat(poolingOptions.getMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL)).isEqualTo(0);
+        assertThat(poolingOptions.getMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL)).isEqualTo(128);
+
+        assertThat(poolingOptions.getCoreConnectionsPerHost(HostDistance.REMOTE)).isEqualTo(2);
+        assertThat(poolingOptions.getMaxConnectionsPerHost(HostDistance.REMOTE)).isEqualTo(64);
+        assertThat(poolingOptions.getMinSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE)).isEqualTo(0);
+        assertThat(poolingOptions.getMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.REMOTE)).isEqualTo(128);
     }
 
-    private HostDistanceOptions createHostDistanceOptions(int coreConnections, int maxConnections, int maxSimultaneousRequests, int minSimultaneousRequests) {
+    private HostDistanceOptions createHostDistanceOptions(int coreConnections, int maxConnections, int minSimultaneousRequests, int maxSimultaneousRequests) {
         HostDistanceOptions options = new HostDistanceOptions();
         options.setCoreConnections(coreConnections);
         options.setMaxConnections(maxConnections);
-        options.setMaxSimultaneousRequests(maxSimultaneousRequests);
         options.setMinSimultaneousRequests(minSimultaneousRequests);
+        options.setMaxSimultaneousRequests(maxSimultaneousRequests);
         return options;
     }
 

--- a/src/test/resources/smoke/poolingOptions.yml
+++ b/src/test/resources/smoke/poolingOptions.yml
@@ -10,5 +10,5 @@ cassandra:
     remote:
       minSimultaneousRequests: 10
       maxSimultaneousRequests: 50
-      coreConnections: 2
+      coreConnections: 1
       maxConnections: 1


### PR DESCRIPTION
Upgraded to 2.0.3 Datastax Cassandra Driver to fix a number of issues, specially https://datastax-oss.atlassian.net/browse/JAVA-367. 

Since validation of PoolingOptions changed, previous values were invalid and those were changed accordingly.
