### PR TITLE
Do not produce unnecessary log entry when instantiating an ObjectMapper.

### DIFF
--- a/src/main/resources/META-INF/services/org.stuartgunter.dropwizard.cassandra.retry.RetryPolicyFactory
+++ b/src/main/resources/META-INF/services/org.stuartgunter.dropwizard.cassandra.retry.RetryPolicyFactory
@@ -2,4 +2,3 @@ org.stuartgunter.dropwizard.cassandra.retry.DefaultRetryPolicyFactory
 org.stuartgunter.dropwizard.cassandra.retry.DowngradingConsistencyRetryPolicyFactory
 org.stuartgunter.dropwizard.cassandra.retry.FallthroughRetryPolicyFactory
 org.stuartgunter.dropwizard.cassandra.retry.LoggingRetryPolicyFactory
-

--- a/src/test/java/org/stuartgunter/dropwizard/cassandra/LoggingIntegrationTest.java
+++ b/src/test/java/org/stuartgunter/dropwizard/cassandra/LoggingIntegrationTest.java
@@ -1,0 +1,50 @@
+package org.stuartgunter.dropwizard.cassandra;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.google.common.io.Resources;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import org.stuartgunter.dropwizard.cassandra.smoke.SmokeTestApp;
+import org.stuartgunter.dropwizard.cassandra.smoke.SmokeTestConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+public class LoggingIntegrationTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<SmokeTestConfiguration> APP =
+        new DropwizardAppRule<>(SmokeTestApp.class, Resources.getResource("minimal.yml").getPath());
+
+    @Test
+    public void doesNotProduceLogEntriesWhenInstantiatingObjectMapper() {
+        LogCapturing.start();
+        Jackson.newObjectMapper();
+        LogCapturing.verifyNoLogMessagesProduced();
+    }
+
+    private static class LogCapturing {
+
+        private static ArgumentCaptor<ILoggingEvent> argumentCaptor;
+
+        public static void start() {
+            Appender<ILoggingEvent> logAppender = mock(Appender.class);
+            Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+            root.addAppender(logAppender);
+            argumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+            doNothing().when(logAppender).doAppend(argumentCaptor.capture());
+        }
+
+        public static void verifyNoLogMessagesProduced() {
+            assertThat(argumentCaptor.getAllValues()).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Every time an ObjectMapper is instantiated while Dropwizard Cassandra
is on the classpath, Jackson produces the following log entry:

 INFO io.dropwizard.jackson.DiscoverableSubtypeResolver: Unable to load

This happens because Dropwizard’s DiscoverableSubtypeResolver assumes
each line in every file in META-INF/services is a valid fully qualified
class name and attempts to load it. When it’s not able to load a class
with an empty string as its name, it produces the log entry.
