### PR TITLE
HealthCheck fix for Datastax Java Driver 3.x

### DIFF
--- a/src/main/java/systems/composable/dropwizard/cassandra/CassandraFactory.java
+++ b/src/main/java/systems/composable/dropwizard/cassandra/CassandraFactory.java
@@ -161,7 +161,7 @@ public class CassandraFactory {
     private String keyspace;
 
     @NotEmpty
-    private String validationQuery = "SELECT * FROM system_schema.keyspaces";
+    private String validationQuery = "SELECT key FROM system.local";
 
     @NotEmpty
     private String[] contactPoints;


### PR DESCRIPTION
The system_schema keyspace is not available anymore in Datastax Java Driver 3.0 so the validation query fails with the current master.
Changed it to "SELECT key FROM system.local"
