### PR TITLE
Make ContactPoints configurable

### DIFF
--- a/src/main/java/systems/composable/dropwizard/cassandra/contactpoints/ContactPointsFactory.java
+++ b/src/main/java/systems/composable/dropwizard/cassandra/contactpoints/ContactPointsFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Homeaway, Inc 2016. All Rights Reserved.
+ * No unauthorized use of this software.
+ */
+
+package systems.composable.dropwizard.cassandra.contactpoints;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.dropwizard.jackson.Discoverable;
+
+/**
+ * @see StaticHostContactsPointFactory
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface ContactPointsFactory extends Discoverable {
+
+    String[] build();
+}

--- a/src/main/java/systems/composable/dropwizard/cassandra/contactpoints/StaticHostContactsPointFactory.java
+++ b/src/main/java/systems/composable/dropwizard/cassandra/contactpoints/StaticHostContactsPointFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Homeaway, Inc 2016. All Rights Reserved.
+ * No unauthorized use of this software.
+ */
+
+package systems.composable.dropwizard.cassandra.contactpoints;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.hibernate.validator.constraints.NotEmpty;
+
+/**
+ *
+ */
+@JsonTypeName("static")
+public class StaticHostContactsPointFactory implements ContactPointsFactory {
+
+    @NotEmpty
+    private String[] contactPoints;
+
+    @JsonProperty
+    public String[] getContactPoints() {
+        return contactPoints;
+    }
+
+    @JsonProperty
+    public void setContactPoints(String[] contactPoints) {
+        this.contactPoints = contactPoints;
+    }
+
+    @Override
+    public String[] build() {
+        return this.contactPoints;
+    }
+}

--- a/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
+++ b/src/main/resources/META-INF/services/io.dropwizard.jackson.Discoverable
@@ -1,4 +1,5 @@
 systems.composable.dropwizard.cassandra.auth.AuthProviderFactory
+systems.composable.dropwizard.cassandra.contactpoints.ContactPointsFactory
 systems.composable.dropwizard.cassandra.reconnection.ReconnectionPolicyFactory
 systems.composable.dropwizard.cassandra.retry.RetryPolicyFactory
 systems.composable.dropwizard.cassandra.loadbalancing.LoadBalancingPolicyFactory

--- a/src/main/resources/META-INF/services/systems.composable.dropwizard.cassandra.contactpoints.ContactPointsFactory
+++ b/src/main/resources/META-INF/services/systems.composable.dropwizard.cassandra.contactpoints.ContactPointsFactory
@@ -1,0 +1,1 @@
+systems.composable.dropwizard.cassandra.contactpoints.StaticHostContactsPointFactory

--- a/src/test/resources/minimal.yml
+++ b/src/test/resources/minimal.yml
@@ -1,3 +1,5 @@
 cassandra:
   clusterName: "minimal-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]

--- a/src/test/resources/multiCluster/multiCluster.yml
+++ b/src/test/resources/multiCluster/multiCluster.yml
@@ -1,9 +1,13 @@
 cassandra1:
   clusterName: "cluster1"
   keyspace: "ks1"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
 
 cassandra2:
   clusterName: "cluster2"
   keyspace: "ks2"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]

--- a/src/test/resources/smoke/auth/authProvider-plainText.yml
+++ b/src/test/resources/smoke/auth/authProvider-plainText.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   authProvider:
     type: plainText
     username: some_username

--- a/src/test/resources/smoke/basic.yml
+++ b/src/test/resources/smoke/basic.yml
@@ -1,7 +1,9 @@
 cassandra:
   clusterName: "smoke-cluster"
   keyspace: "system"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   port: 9042
   protocolVersion: "V4"
   compression: "LZ4"

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-dcAwareRoundRobin.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-dcAwareRoundRobin.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: dcAwareRoundRobin
     localDC: dc1

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-errorAware.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-errorAware.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: errorAware
     maxErrorsPerMinute: 5

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-latencyAware.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-latencyAware.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: latencyAware
     exclusionThreshold: 1.0

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-roundRobin.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-roundRobin.yml
@@ -1,5 +1,7 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: roundRobin

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-tokenAware.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-tokenAware.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: tokenAware
     shuffleReplicas: true

--- a/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-whiteList.yml
+++ b/src/test/resources/smoke/loadbalancing/loadBalancingPolicy-whiteList.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   loadBalancingPolicy:
     type: whiteList
     subPolicy:

--- a/src/test/resources/smoke/poolingOptions.yml
+++ b/src/test/resources/smoke/poolingOptions.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   poolingOptions:
     heartbeatInterval: 5 seconds
     poolTimeout: 2 seconds

--- a/src/test/resources/smoke/queryOptions.yml
+++ b/src/test/resources/smoke/queryOptions.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   queryOptions:
     consistencyLevel: "TWO"
     serialConsistencyLevel: "TWO"

--- a/src/test/resources/smoke/reconnection/reconnectionPolicy-constant.yml
+++ b/src/test/resources/smoke/reconnection/reconnectionPolicy-constant.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   reconnectionPolicy:
     type: constant
     delay: 10 milliseconds

--- a/src/test/resources/smoke/reconnection/reconnectionPolicy-exponential.yml
+++ b/src/test/resources/smoke/reconnection/reconnectionPolicy-exponential.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   reconnectionPolicy:
     type: exponential
     baseDelay: 10 milliseconds

--- a/src/test/resources/smoke/retry/retryPolicy-default.yml
+++ b/src/test/resources/smoke/retry/retryPolicy-default.yml
@@ -1,5 +1,7 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   retryPolicy:
     type: default

--- a/src/test/resources/smoke/retry/retryPolicy-downgradingConsistency.yml
+++ b/src/test/resources/smoke/retry/retryPolicy-downgradingConsistency.yml
@@ -1,5 +1,7 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   retryPolicy:
     type: downgradingConsistency

--- a/src/test/resources/smoke/retry/retryPolicy-fallthrough.yml
+++ b/src/test/resources/smoke/retry/retryPolicy-fallthrough.yml
@@ -1,5 +1,7 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   retryPolicy:
     type: fallthrough

--- a/src/test/resources/smoke/retry/retryPolicy-log.yml
+++ b/src/test/resources/smoke/retry/retryPolicy-log.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   retryPolicy:
     type: log
     subPolicy:

--- a/src/test/resources/smoke/socketOptions.yml
+++ b/src/test/resources/smoke/socketOptions.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   socketOptions:
     connectTimeoutMillis: 5000
     readTimeoutMillis: 12000

--- a/src/test/resources/smoke/speculativeexecution/speculativeExecutionPolicy-constant.yml
+++ b/src/test/resources/smoke/speculativeexecution/speculativeExecutionPolicy-constant.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   speculativeExecutionPolicy:
     type: constant
     delay: 500 milliseconds

--- a/src/test/resources/smoke/speculativeexecution/speculativeExecutionPolicy-none.yml
+++ b/src/test/resources/smoke/speculativeexecution/speculativeExecutionPolicy-none.yml
@@ -1,5 +1,7 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   speculativeExecutionPolicy:
     type: none

--- a/src/test/resources/smoke/ssl/ssl-jdk.yml
+++ b/src/test/resources/smoke/ssl/ssl-jdk.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   port: 9142
   ssl:
     type: jdk

--- a/src/test/resources/smoke/ssl/ssl-netty.yml
+++ b/src/test/resources/smoke/ssl/ssl-netty.yml
@@ -1,6 +1,8 @@
 cassandra:
   clusterName: "smoke-cluster"
-  contactPoints: ["localhost"]
+  contactPoints:
+    type: static
+    contactPoints: ["localhost"]
   port: 9142
   ssl:
     type: netty


### PR DESCRIPTION
@stuartgunter what do you think of making contactPoints into a factory instead of a static array in the yaml.  I allowed for a static array solution to be available by default but allows other applications to register their own types for how they want to inject the contact points(saying using service discovery in consul or zookeeper or etcd).
